### PR TITLE
Add theming to Demo app

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		6771E7B2299C00050012002D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6771E7B1299C00050012002D /* ViewController.swift */; };
 		6771E7B7299C00060012002D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6771E7B6299C00060012002D /* Assets.xcassets */; };
 		6771E7BA299C00060012002D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6771E7B8299C00060012002D /* LaunchScreen.storyboard */; };
+		67D4AD632A044F9D00F3D066 /* WKAppEnvironment+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D4AD622A044F9D00F3D066 /* WKAppEnvironment+Extensions.swift */; };
+		67D4AD662A044FA700F3D066 /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D4AD642A044FA700F3D066 /* UserDefaults+Extensions.swift */; };
+		67D4AD672A044FA700F3D066 /* SelectThemeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D4AD652A044FA700F3D066 /* SelectThemeViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +29,9 @@
 		6771E7B6299C00060012002D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6771E7B9299C00060012002D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6771E7BB299C00060012002D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		67D4AD622A044F9D00F3D066 /* WKAppEnvironment+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKAppEnvironment+Extensions.swift"; sourceTree = "<group>"; };
+		67D4AD642A044FA700F3D066 /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
+		67D4AD652A044FA700F3D066 /* SelectThemeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectThemeViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +71,9 @@
 				6771E7AF299C00050012002D /* SceneDelegate.swift */,
 				6771E7B1299C00050012002D /* ViewController.swift */,
 				006B8EF92A005EE300D01FC2 /* RootWindow.swift */,
+				67D4AD622A044F9D00F3D066 /* WKAppEnvironment+Extensions.swift */,
+				67D4AD652A044FA700F3D066 /* SelectThemeViewController.swift */,
+				67D4AD642A044FA700F3D066 /* UserDefaults+Extensions.swift */,
 				6771E7B6299C00060012002D /* Assets.xcassets */,
 				6771E7B8299C00060012002D /* LaunchScreen.storyboard */,
 				6771E7BB299C00060012002D /* Info.plist */,
@@ -152,9 +161,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67D4AD632A044F9D00F3D066 /* WKAppEnvironment+Extensions.swift in Sources */,
 				6771E7B2299C00050012002D /* ViewController.swift in Sources */,
+				67D4AD672A044FA700F3D066 /* SelectThemeViewController.swift in Sources */,
 				6771E7AE299C00050012002D /* AppDelegate.swift in Sources */,
 				6771E7B0299C00050012002D /* SceneDelegate.swift in Sources */,
+				67D4AD662A044FA700F3D066 /* UserDefaults+Extensions.swift in Sources */,
 				006B8EFA2A005EE300D01FC2 /* RootWindow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/Demo/RootWindow.swift
+++ b/Demo/Demo/RootWindow.swift
@@ -3,11 +3,21 @@ import Components
 
 /// The root window for the demo app. Trait collection changes are fed into the Components system here.
 final class RootWindow: UIWindow {
-
+    
+    override init(windowScene: UIWindowScene) {
+        super.init(windowScene: windowScene)
+        
+        WKAppEnvironment.updateWithTraitCollection(traitCollection)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
 	override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
 		super.traitCollectionDidChange(previousTraitCollection)
 
-		WKAppEnvironment.current.set(theme: traitCollection.userInterfaceStyle == .light ? WKTheme.light : WKTheme.dark, traitCollection: traitCollection)
+        WKAppEnvironment.updateWithTraitCollection(traitCollection)
 	}
 
 }

--- a/Demo/Demo/SelectThemeViewController.swift
+++ b/Demo/Demo/SelectThemeViewController.swift
@@ -1,7 +1,13 @@
 import UIKit
 import Components
 
-class ViewController: WKCanvasViewController {
+struct ThemeButtonViewModel {
+    let title: String
+    let themeName: String
+}
+
+class SelectThemeViewController: WKCanvasViewController {
+
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -17,19 +23,19 @@ class ViewController: WKCanvasViewController {
         return stackView
     }()
     
-    private lazy var selectThemeButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.setTitle("Select Theme", for: .normal)
-        button.addTarget(self, action: #selector(tappedSelectTheme), for: .touchUpInside)
-        return button
-    }()
-    
+    private let viewModels = [
+        ThemeButtonViewModel(title: "Default", themeName: "Default"),
+        ThemeButtonViewModel(title: WKTheme.light.name, themeName: WKTheme.light.name),
+        ThemeButtonViewModel(title: WKTheme.sepia.name, themeName: WKTheme.sepia.name),
+        ThemeButtonViewModel(title: WKTheme.dark.name, themeName: WKTheme.dark.name),
+        ThemeButtonViewModel(title: WKTheme.black.name, themeName: WKTheme.black.name),
+    ]
+
     override func viewDidLoad() {
         super.viewDidLoad()
        
         setupInitialViews()
-        stackView.addArrangedSubview(selectThemeButton)
+        addThemeButtons()
     }
     
     private func setupInitialViews() {
@@ -49,8 +55,32 @@ class ViewController: WKCanvasViewController {
         ])
     }
     
-    @objc private func tappedSelectTheme() {
-        let vc = SelectThemeViewController()
-        present(vc, animated: true)
+    private func addThemeButtons() {
+        
+        for (index, viewModel) in viewModels.enumerated() {
+            let button = UIButton(type: .system)
+            button.titleLabel?.adjustsFontForContentSizeCategory = true
+            button.setTitle(viewModel.title, for: .normal)
+            button.tag = index
+            button.addTarget(self, action: #selector(tappedButton(_:)), for: .touchUpInside)
+            stackView.addArrangedSubview(button)
+        }
+        
+        updateButtonSelectedStates()
+    }
+            
+    @objc private func tappedButton(_ sender : UIButton) {
+        let viewModel = viewModels[sender.tag]
+        UserDefaults.standard.themeName = viewModel.themeName
+        WKAppEnvironment.updateWithTraitCollection(traitCollection)
+        updateButtonSelectedStates()
+    }
+    
+    func updateButtonSelectedStates() {
+        for (subview, theme) in zip(stackView.arrangedSubviews, viewModels) {
+            if let button = subview as? UIButton {
+                button.isSelected = theme.themeName == UserDefaults.standard.themeName
+            }
+        }
     }
 }

--- a/Demo/Demo/UserDefaults+Extensions.swift
+++ b/Demo/Demo/UserDefaults+Extensions.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+let WKThemeNameKey = "WKThemeNameKey"
+
+extension UserDefaults {
+    @objc var themeName: String? {
+        get {
+            return string(forKey: WKThemeNameKey)
+        }
+        set {
+            set(newValue, forKey: WKThemeNameKey)
+        }
+    }
+
+}

--- a/Demo/Demo/WKAppEnvironment+Extensions.swift
+++ b/Demo/Demo/WKAppEnvironment+Extensions.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Components
+import UIKit
+
+extension WKAppEnvironment {
+    static func updateWithTraitCollection(_ traitCollection: UITraitCollection) {
+        switch UserDefaults.standard.themeName {
+        case "Light":
+            WKAppEnvironment.current.set(theme: WKTheme.light, traitCollection: traitCollection)
+        case "Sepia":
+            WKAppEnvironment.current.set(theme: WKTheme.sepia, traitCollection: traitCollection)
+        case "Dark":
+            WKAppEnvironment.current.set(theme: WKTheme.dark, traitCollection: traitCollection)
+        case "Black":
+            WKAppEnvironment.current.set(theme: WKTheme.black, traitCollection: traitCollection)
+        default:
+            WKAppEnvironment.current.set(theme: traitCollection.userInterfaceStyle == .light ? WKTheme.light : WKTheme.black, traitCollection: traitCollection)
+        }
+    }
+}

--- a/Sources/Components/Base/WKCanvas.swift
+++ b/Sources/Components/Base/WKCanvas.swift
@@ -4,7 +4,7 @@ import UIKit
 public class WKCanvas: WKComponentView {
 
 	public override func appEnvironmentDidChange() {
-		backgroundColor = WKAppEnvironment.current.theme.background
+		backgroundColor = WKAppEnvironment.current.theme.paperBackground
 	}
 
 }

--- a/Sources/Components/Style/WKColor.swift
+++ b/Sources/Components/Style/WKColor.swift
@@ -4,7 +4,8 @@ import SwiftUI
 enum WKColor {
 
 	static let white = UIColor.white
-	static let black = UIColor.black
-
+    static let beige100 = UIColor(red: 248/255, green: 241/255, blue: 227/255, alpha: 1.0)
+    static let gray675 = UIColor(red: 39/255, green: 41/255, blue: 45/255, alpha: 1.0)
+    static let black = UIColor.black
 }
 

--- a/Sources/Components/Style/WKTheme.swift
+++ b/Sources/Components/Style/WKTheme.swift
@@ -3,26 +3,26 @@ import UIKit
 public struct WKTheme: Equatable {
 
 	public let name: String
-	public let background: UIColor
+    public let paperBackground: UIColor
 
 	public static let light = WKTheme(
 		name: "Light",
-		background: WKColor.white
+        paperBackground: WKColor.white
 	)
+    
+    public static let sepia = WKTheme(
+        name: "Sepia",
+        paperBackground: WKColor.beige100
+    )
 
 	public static let dark = WKTheme(
 		name: "Dark",
-		background: WKColor.black
+        paperBackground: WKColor.gray675
 	)
 
 	public static let black = WKTheme(
 		name: "Black",
-		background: WKColor.black
-	)
-
-	public static let sepia = WKTheme(
-		name: "Sepia",
-		background: WKColor.white
+        paperBackground: WKColor.black
 	)
 
 }


### PR DESCRIPTION
**Phabricator:** 
N/A

### Notes
This adds some basic theme selection / persistence to the demo app, and adds `paperBackground` as a color. This will help confirm our UI is theming correctly as we build out native editor.

**Test Steps**
Confirm theme selection persists between launches and works as expected. Confirm the Canvas background reflects the `paperBackround` color, and the default theme selection switches between light and black based on the system dark mode.

