### PR TITLE
Add `WKMenuButton`

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		006B8EFA2A005EE300D01FC2 /* RootWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006B8EF92A005EE300D01FC2 /* RootWindow.swift */; };
+		00FBBBB92A14206600453DE5 /* MenuButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FBBBB82A14206600453DE5 /* MenuButtonViewController.swift */; };
 		67359891299ED732002EE8D1 /* Components in Frameworks */ = {isa = PBXBuildFile; productRef = 67359890299ED732002EE8D1 /* Components */; };
 		6771E7AE299C00050012002D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6771E7AD299C00050012002D /* AppDelegate.swift */; };
 		6771E7B0299C00050012002D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6771E7AF299C00050012002D /* SceneDelegate.swift */; };
@@ -21,6 +22,7 @@
 
 /* Begin PBXFileReference section */
 		006B8EF92A005EE300D01FC2 /* RootWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootWindow.swift; sourceTree = "<group>"; };
+		00FBBBB82A14206600453DE5 /* MenuButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuButtonViewController.swift; sourceTree = "<group>"; };
 		6735988F299ED71F002EE8D1 /* wikipedia-ios-components */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "wikipedia-ios-components"; path = ..; sourceTree = "<group>"; };
 		6771E7AA299C00050012002D /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6771E7AD299C00050012002D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -46,6 +48,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		00FBBBB72A14205100453DE5 /* Menu Button */ = {
+			isa = PBXGroup;
+			children = (
+				00FBBBB82A14206600453DE5 /* MenuButtonViewController.swift */,
+			);
+			path = "Menu Button";
+			sourceTree = "<group>";
+		};
 		6771E7A1299C00050012002D = {
 			isa = PBXGroup;
 			children = (
@@ -67,6 +77,7 @@
 		6771E7AC299C00050012002D /* Demo */ = {
 			isa = PBXGroup;
 			children = (
+				00FBBBB72A14205100453DE5 /* Menu Button */,
 				6771E7AD299C00050012002D /* AppDelegate.swift */,
 				6771E7AF299C00050012002D /* SceneDelegate.swift */,
 				6771E7B1299C00050012002D /* ViewController.swift */,
@@ -162,6 +173,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				67D4AD632A044F9D00F3D066 /* WKAppEnvironment+Extensions.swift in Sources */,
+				00FBBBB92A14206600453DE5 /* MenuButtonViewController.swift in Sources */,
 				6771E7B2299C00050012002D /* ViewController.swift in Sources */,
 				67D4AD672A044FA700F3D066 /* SelectThemeViewController.swift in Sources */,
 				6771E7AE299C00050012002D /* AppDelegate.swift in Sources */,

--- a/Demo/Demo/Menu Button/MenuButtonViewController.swift
+++ b/Demo/Demo/Menu Button/MenuButtonViewController.swift
@@ -1,0 +1,56 @@
+import UIKit
+import Components
+
+final class MenuButtonViewController: WKCanvasViewController {
+
+	override func viewDidLoad() {
+		super.viewDidLoad()
+
+		let buttonConfiguration1 = WKMenuButton.Configuration(
+			title: "Username",
+			image: UIImage(systemName: "person.fill"),
+			primaryColor: \.link,
+			menuItems: [
+				WKMenuButton.MenuItem(title: "User page", image: UIImage(systemName: "person.fill")),
+				WKMenuButton.MenuItem(title: "Talk page", image: UIImage(systemName: "bubble.left.and.bubble.right")),
+				WKMenuButton.MenuItem(title: "User contributions", image: UIImage(systemName: "person.text.rectangle"))
+			]
+		)
+
+		let buttonConfiguration2 = WKMenuButton.Configuration(
+			title: "Username",
+			image: UIImage(systemName: "person.fill"),
+			primaryColor: \.diffCompareAccent,
+			menuItems: [
+				WKMenuButton.MenuItem(title: "User page", image: UIImage(systemName: "person.fill")),
+				WKMenuButton.MenuItem(title: "Talk page", image: UIImage(systemName: "bubble.left.and.bubble.right")),
+				WKMenuButton.MenuItem(title: "User contributions", image: UIImage(systemName: "person.text.rectangle"))
+			]
+		)
+
+		let button1 = WKMenuButton(configuration: buttonConfiguration1)
+		button1.delegate = self
+		canvas.addSubview(button1)
+
+		let button2 = WKMenuButton(configuration: buttonConfiguration2)
+		button2.delegate = self
+		canvas.addSubview(button2)
+
+		NSLayoutConstraint.activate([
+			button1.centerXAnchor.constraint(equalTo: canvas.centerXAnchor),
+			button1.centerYAnchor.constraint(equalTo: canvas.centerYAnchor, constant: -50),
+
+			button2.centerXAnchor.constraint(equalTo: canvas.centerXAnchor),
+			button2.topAnchor.constraint(equalTo: button1.bottomAnchor, constant: 50),
+		])
+	}
+
+}
+
+extension MenuButtonViewController: WKMenuButtonDelegate {
+
+	func wkMenuButton(_ sender: WKMenuButton, didTapMenuItem item: WKMenuButton.MenuItem) {
+		print("User tapped: \(sender) \t menu item \(item.id)")
+	}
+
+}

--- a/Demo/Demo/RootWindow.swift
+++ b/Demo/Demo/RootWindow.swift
@@ -1,12 +1,23 @@
 import UIKit
+import Combine
 import Components
 
 /// The root window for the demo app. Trait collection changes are fed into the Components system here.
 final class RootWindow: UIWindow {
-    
+
+	// MARK: - Private Properties
+
+	private var cancellables = Set<AnyCancellable>()
+
+	// MARK: - Lifecycle
+
     override init(windowScene: UIWindowScene) {
         super.init(windowScene: windowScene)
-        
+
+		WKAppEnvironment.current.$theme.sink(receiveValue: { theme in
+			self.overrideUserInterfaceStyle = theme.userInterfaceStyle
+		}).store(in: &cancellables)
+
         WKAppEnvironment.updateWithTraitCollection(traitCollection)
     }
     

--- a/Demo/Demo/RootWindow.swift
+++ b/Demo/Demo/RootWindow.swift
@@ -15,7 +15,7 @@ final class RootWindow: UIWindow {
         super.init(windowScene: windowScene)
 
 		WKAppEnvironment.current.$theme.sink(receiveValue: { theme in
-			self.overrideUserInterfaceStyle = theme.userInterfaceStyle
+			self.overrideUserInterfaceStyle = UserDefaults.standard.themeName == "Default" ? .unspecified : theme.userInterfaceStyle
 		}).store(in: &cancellables)
 
         WKAppEnvironment.updateWithTraitCollection(traitCollection)

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -54,8 +54,6 @@ class ViewController: WKCanvasViewController {
 
 	override func viewDidAppear(_ animated: Bool) {
 		super.viewDidAppear(animated)
-
-		tappedMenuButton()
 	}
     
     private func setupInitialViews() {

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -32,6 +32,15 @@ class ViewController: WKCanvasViewController {
         button.addTarget(self, action: #selector(tappedSourceEditor), for: .touchUpInside)
         return button
     }()
+
+	private lazy var menuButtonButton: UIButton = {
+		let button = UIButton(type: .system)
+		button.titleLabel?.adjustsFontForContentSizeCategory = true
+		button.setTitle("Menu Button", for: .normal)
+		button.addTarget(self, action: #selector(tappedMenuButton), for: .touchUpInside)
+		return button
+	}()
+
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -40,7 +49,14 @@ class ViewController: WKCanvasViewController {
         
         stackView.addArrangedSubview(selectThemeButton)
         stackView.addArrangedSubview(sourceEditorButton)
+		stackView.addArrangedSubview(menuButtonButton)
     }
+
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+
+		tappedMenuButton()
+	}
     
     private func setupInitialViews() {
         view.addSubview(scrollView)
@@ -69,6 +85,12 @@ class ViewController: WKCanvasViewController {
         let viewController = WKSourceEditorViewController(viewModel: viewModel, delegate: self)
         present(viewController, animated: true)
     }
+
+	@objc private func tappedMenuButton() {
+		let viewController = MenuButtonViewController()
+		present(viewController, animated: true)
+	}
+
 }
 
 extension ViewController: WKSourceEditorViewControllerDelegate {

--- a/Sources/Components/Base/WKCanvasViewController.swift
+++ b/Sources/Components/Base/WKCanvasViewController.swift
@@ -4,6 +4,12 @@ import SwiftUI
 /// A base `UIKit` WKCanvasViewController to add Components to that automatically subscribes to `AppEnvironment` changes
 open class WKCanvasViewController: WKComponentViewController {
 
+	// MARK: - Properties
+
+	public var canvas: WKCanvas {
+		return view as! WKCanvas
+	}
+
 	// MARK: - Lifecycle
 
 	public override func loadView() {

--- a/Sources/Components/Components/Shared/Buttons/WKButton.swift
+++ b/Sources/Components/Components/Shared/Buttons/WKButton.swift
@@ -1,0 +1,3 @@
+import UIKit
+
+public class WKButton: UIButton {}

--- a/Sources/Components/Components/Shared/Buttons/WKMenuButton.swift
+++ b/Sources/Components/Components/Shared/Buttons/WKMenuButton.swift
@@ -1,0 +1,130 @@
+import Foundation
+import UIKit
+
+/// A button that displays a `UIMenu` when triggering its primary action
+public class WKMenuButton: WKComponentView {
+
+	// MARK: - Nested Types
+
+	public typealias MenuItem = Configuration.MenuItem
+
+	public struct Configuration {
+
+		// MARK: - Nested Types
+
+		public struct MenuItem {
+			public let id = UUID()
+			let title: String
+			let image: UIImage?
+			let attributes: UIMenu.Attributes
+
+			public init(title: String, image: UIImage? = nil, attributes: UIMenu.Attributes = []) {
+				self.title = title
+				self.image = image
+				self.attributes = attributes
+			}
+		}
+
+		// MARK: - Properties
+
+		let title: String
+		let image: UIImage?
+		let primaryColor: KeyPath<WKTheme, UIColor>
+		let menuItems: [MenuItem]
+
+		// MARK: - Public
+
+		public init(title: String, image: UIImage? = nil, primaryColor: KeyPath<WKTheme, UIColor>,  menuItems: [MenuItem]) {
+			self.title = title
+			self.image = image
+			self.primaryColor = primaryColor
+			self.menuItems = menuItems
+		}
+		
+	}
+
+	// MARK: - Properties
+
+	public weak var delegate: WKMenuButtonDelegate?
+	private let configuration: Configuration
+
+	// MARK: - UI Elements
+
+	private lazy var button: WKButton = {
+		let button = WKButton(type: .custom)
+		button.translatesAutoresizingMaskIntoConstraints = false
+		return button
+	}()
+
+	// MARK: - Public
+
+	public required init(configuration: Configuration) {
+		self.configuration = configuration
+		super.init(frame: .zero)
+		setup()
+	}
+
+	public required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	// MARK: - Setup
+
+	private func setup() {
+		addSubview(button)
+		NSLayoutConstraint.activate([
+			button.leadingAnchor.constraint(equalTo: leadingAnchor),
+			button.trailingAnchor.constraint(equalTo: trailingAnchor),
+			button.topAnchor.constraint(equalTo: topAnchor),
+			button.bottomAnchor.constraint(equalTo: bottomAnchor),
+		])
+
+		button.menu = generateMenu()
+		button.showsMenuAsPrimaryAction = true
+
+		configure()
+	}
+
+	private func configure() {
+		button.backgroundColor = theme[keyPath: configuration.primaryColor].withAlphaComponent(0.15)
+		button.tintColor = theme[keyPath: configuration.primaryColor]
+		button.setTitleColor(theme[keyPath: configuration.primaryColor], for: .normal)
+		button.titleLabel?.font = WKFont.for(.boldFootnote)
+		button.setTitle(configuration.title, for: .normal)
+		button.setImage(configuration.image, for: .normal)
+
+		button.adjustsImageSizeForAccessibilityContentSizeCategory = true
+		button.adjustsImageWhenHighlighted = false
+
+		button.layer.cornerRadius = 8
+		button.layer.cornerCurve = .continuous
+		button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 4, bottom: 0, right: -8)
+		button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 8, bottom: 8, right: 16)
+	}
+
+	private func generateMenu() -> UIMenu {
+		var actions: [UIAction] = []
+		for menuItem in configuration.menuItems.reversed() {
+			let action = UIAction(title: menuItem.title, image: menuItem.image, attributes: menuItem.attributes, handler: { [weak self] _ in
+				self?.userDidTapMenuItem(menuItem)
+			})
+
+			actions.append(action)
+		}
+
+		return UIMenu(children: actions)
+	}
+
+	// MARK: - Button Actions
+
+	private func userDidTapMenuItem(_ item: MenuItem) {
+		delegate?.wkMenuButton(self, didTapMenuItem: item)
+	}
+
+	// MARK: - Component Conformance
+
+	public override func appEnvironmentDidChange() {
+		configure()
+	}
+
+}

--- a/Sources/Components/Components/Shared/Buttons/WKMenuButton.swift
+++ b/Sources/Components/Components/Shared/Buttons/WKMenuButton.swift
@@ -98,8 +98,14 @@ public class WKMenuButton: WKComponentView {
 
 		button.layer.cornerRadius = 8
 		button.layer.cornerCurve = .continuous
-		button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 4, bottom: 0, right: -8)
-		button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 8, bottom: 8, right: 16)
+
+		if effectiveUserInterfaceLayoutDirection == .leftToRight {
+			button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 4, bottom: 0, right: -8)
+			button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 8, bottom: 8, right: 16)
+		} else {
+			button.titleEdgeInsets = UIEdgeInsets(top: 0, left: -8, bottom: 0, right: 4)
+			button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 16, bottom: 8, right: 8)
+		}
 	}
 
 	private func generateMenu() -> UIMenu {

--- a/Sources/Components/Components/Shared/Buttons/WKMenuButtonDelegate.swift
+++ b/Sources/Components/Components/Shared/Buttons/WKMenuButtonDelegate.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+public protocol WKMenuButtonDelegate: AnyObject {
+	func wkMenuButton(_ sender: WKMenuButton, didTapMenuItem item: WKMenuButton.MenuItem)
+}

--- a/Sources/Components/Style/Legacy/UIColor+Extensions.swift
+++ b/Sources/Components/Style/Legacy/UIColor+Extensions.swift
@@ -2,6 +2,35 @@ import UIKit
 
 public extension UIColor {
 
+	static let gray800 = UIColor(0x101418)
+	static let gray700 = UIColor(0x202122)
+	static let gray675 = UIColor(0x27292D)
+	static let gray650 = UIColor(0x2E3136)
+	static let gray600 = UIColor(0x54595D)
+	static let gray500 = UIColor(0x72777D)
+	static let gray400 = UIColor(0xA2A9B1)
+	static let gray300 = UIColor(0xC8CCD1)
+	static let gray200 = UIColor(0xEAECF0)
+	static let gray150 = UIColor(0xEEF2FB)
+	static let gray100 = UIColor(0xF8F9FA)
+	static let blue700 = UIColor(0x2A4B8D)
+	static let blue600 = UIColor(0x3366CC)
+	static let blue300 = UIColor(0x6699FF)
+	static let blue100 = UIColor(0xEAF3FF)
+	static let red700 = UIColor(0xB32424)
+	static let red600 = UIColor(0xDD3333)
+	static let red100 = UIColor(0xFEE7E6)
+	static let green600 = UIColor(0x00AF89)
+	static let green100 = UIColor(0xD5FDF4)
+	static let yellow600 = UIColor(0xFFCC33)
+	static let beige400 = UIColor(0xE1DAD1)
+	static let beige300 = UIColor(0xF0E6D6)
+	static let beige100 = UIColor(0xF8F1E3)
+	static let taupe600 = UIColor(0x646059)
+	static let taupe200 = UIColor(0xCBC8C1)
+	static let purple600 = UIColor(0x6b4ba1)
+	static let orange600 = UIColor(0xFF9500)
+
     convenience init(_ hex: Int, alpha: CGFloat) {
         let r = CGFloat((hex & 0xFF0000) >> 16) / 255.0
         let g = CGFloat((hex & 0xFF00) >> 8) / 255.0

--- a/Sources/Components/Style/Legacy/UIColor+Extensions.swift
+++ b/Sources/Components/Style/Legacy/UIColor+Extensions.swift
@@ -1,42 +1,6 @@
 import UIKit
 
-/// Color definitions from Wikimedia Style Guide
 public extension UIColor {
-
-    static let gray800 = UIColor(0x101418)
-    static let gray700 = UIColor(0x202122)
-    static let gray675 = UIColor(0x27292D)
-    static let gray650 = UIColor(0x2E3136)
-    static let gray600 = UIColor(0x54595D)
-    static let gray500 = UIColor(0x72777D)
-    static let gray400 = UIColor(0xA2A9B1)
-    static let gray300 = UIColor(0xC8CCD1)
-    static let gray200 = UIColor(0xEAECF0)
-    static let gray150 = UIColor(0xEEF2FB)
-    static let gray100 = UIColor(0xF8F9FA)
-    static let blue700 = UIColor(0x2A4B8D)
-    static let blue600 = UIColor(0x3366CC)
-    static let blue300 = UIColor(0x6699FF)
-    static let blue100 = UIColor(0xEAF3FF)
-    static let red700 = UIColor(0xB32424)
-    static let red600 = UIColor(0xDD3333)
-    static let red100 = UIColor(0xFEE7E6)
-    static let green600 = UIColor(0x00AF89)
-    static let green100 = UIColor(0xD5FDF4)
-    static let yellow600 = UIColor(0xFFCC33)
-    static let beige400 = UIColor(0xE1DAD1)
-    static let beige300 = UIColor(0xF0E6D6)
-    static let beige100 = UIColor(0xF8F1E3)
-    static let taupe600 = UIColor(0x646059)
-    static let taupe200 = UIColor(0xCBC8C1)
-    static let purple600 = UIColor(0x6b4ba1)
-    static let orange600 = UIColor(0xFF9500)
-    static let darkSearchFieldBackground = UIColor(0x8E8E93, alpha: 0.12)
-    static let lightSearchFieldBackground = UIColor(0xFFFFFF, alpha: 0.15)
-
-}
-
-private extension UIColor {
 
     convenience init(_ hex: Int, alpha: CGFloat) {
         let r = CGFloat((hex & 0xFF0000) >> 16) / 255.0

--- a/Sources/Components/Style/Legacy/UIColor+Extensions.swift
+++ b/Sources/Components/Style/Legacy/UIColor+Extensions.swift
@@ -31,6 +31,9 @@ public extension UIColor {
 	static let purple600 = UIColor(0x6b4ba1)
 	static let orange600 = UIColor(0xFF9500)
 
+	static let darkSearchFieldBackground = UIColor(0x8E8E93, alpha: 0.12)
+	static let lightSearchFieldBackground = UIColor(0xFFFFFF, alpha: 0.15)
+
     convenience init(_ hex: Int, alpha: CGFloat) {
         let r = CGFloat((hex & 0xFF0000) >> 16) / 255.0
         let g = CGFloat((hex & 0xFF00) >> 8) / 255.0

--- a/Sources/Components/Style/WKColor.swift
+++ b/Sources/Components/Style/WKColor.swift
@@ -1,26 +1,42 @@
 import UIKit
 import SwiftUI
 
+/// Color definitions from Wikimedia Style Guide
 enum WKColor {
-    static let black = UIColor.black
-    static let gray800 = UIColor.gray800
-    static let gray700 = UIColor.gray700
-    static let gray675 = UIColor.gray675
-    static let gray650 = UIColor.gray650
-    static let gray600 = UIColor.gray600
-    static let gray500 = UIColor.gray500
-    static let gray400 = UIColor.gray400
-    static let gray300 = UIColor.gray300
-    static let gray200 = UIColor.gray200
-    static let gray100 = UIColor.gray100
-    static let blue600 = UIColor.blue600
-    static let blue300 = UIColor.blue300
-    static let red700 = UIColor.red700
-    static let red600 = UIColor.red600
-    static let taupe600 = UIColor.taupe600
-    static let taupe200 = UIColor.taupe200
-    static let beige400 = UIColor.beige400
-    static let beige300 = UIColor.beige300
-    static let beige100 = UIColor.beige100
+
+	static let black = UIColor.black
 	static let white = UIColor.white
+	
+	static let gray800 = UIColor(0x101418)
+	static let gray700 = UIColor(0x202122)
+	static let gray675 = UIColor(0x27292D)
+	static let gray650 = UIColor(0x2E3136)
+	static let gray600 = UIColor(0x54595D)
+	static let gray500 = UIColor(0x72777D)
+	static let gray400 = UIColor(0xA2A9B1)
+	static let gray300 = UIColor(0xC8CCD1)
+	static let gray200 = UIColor(0xEAECF0)
+	static let gray150 = UIColor(0xEEF2FB)
+	static let gray100 = UIColor(0xF8F9FA)
+	static let blue700 = UIColor(0x2A4B8D)
+	static let blue600 = UIColor(0x3366CC)
+	static let blue300 = UIColor(0x6699FF)
+	static let blue100 = UIColor(0xEAF3FF)
+	static let red700 = UIColor(0xB32424)
+	static let red600 = UIColor(0xDD3333)
+	static let red100 = UIColor(0xFEE7E6)
+	static let green600 = UIColor(0x00AF89)
+	static let green100 = UIColor(0xD5FDF4)
+	static let yellow600 = UIColor(0xFFCC33)
+	static let beige400 = UIColor(0xE1DAD1)
+	static let beige300 = UIColor(0xF0E6D6)
+	static let beige100 = UIColor(0xF8F1E3)
+	static let taupe600 = UIColor(0x646059)
+	static let taupe200 = UIColor(0xCBC8C1)
+	static let purple600 = UIColor(0x6b4ba1)
+	static let orange600 = UIColor(0xFF9500)
+	
+	static let darkSearchFieldBackground = UIColor(0x8E8E93, alpha: 0.12)
+	static let lightSearchFieldBackground = UIColor(0xFFFFFF, alpha: 0.15)
+
 }

--- a/Sources/Components/Style/WKFont.swift
+++ b/Sources/Components/Style/WKFont.swift
@@ -5,6 +5,7 @@ enum WKFont {
     case headline
 	case body
     case caption1
+	case boldFootnote
 
 	static func `for`(_ font: WKFont, compatibleWith traitCollection: UITraitCollection = WKAppEnvironment.current.traitCollection) -> UIFont {
 		switch font {
@@ -14,6 +15,11 @@ enum WKFont {
 			return UIFont.preferredFont(forTextStyle: .body, compatibleWith: traitCollection)
         case .caption1:
             return UIFont.preferredFont(forTextStyle: .caption1, compatibleWith: traitCollection)
+		case .boldFootnote:
+			guard let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote, compatibleWith: traitCollection).withSymbolicTraits(.traitBold) else {
+				fatalError()
+			}
+			return UIFont(descriptor: descriptor, size: 0)
 		}
 	}
 }

--- a/Sources/Components/Style/WKTheme.swift
+++ b/Sources/Components/Style/WKTheme.swift
@@ -3,6 +3,8 @@ import UIKit
 public struct WKTheme: Equatable {
 
 	public let name: String
+	public let userInterfaceStyle: UIUserInterfaceStyle
+	public let keyboardAppearance: UIKeyboardAppearance
     public let text: UIColor
     public let secondaryText: UIColor
     public let link: UIColor
@@ -14,10 +16,12 @@ public struct WKTheme: Equatable {
     public let inputAccessoryButtonSelectedTint: UIColor
     public let inputAccessoryButtonSelectedBackgroundColor: UIColor
     public let keyboardBarSearchFieldBackground: UIColor
-    public let keyboardAppearance: UIKeyboardAppearance
+	public let diffCompareAccent: UIColor
 
 	public static let light = WKTheme(
         name: "Light",
+		userInterfaceStyle: .light,
+		keyboardAppearance: .light,
         text: WKColor.gray700,
         secondaryText: WKColor.gray500,
         link: WKColor.blue600,
@@ -29,55 +33,61 @@ public struct WKTheme: Equatable {
         inputAccessoryButtonSelectedTint: WKColor.gray700,
         inputAccessoryButtonSelectedBackgroundColor: WKColor.gray200,
         keyboardBarSearchFieldBackground: WKColor.gray200,
-        keyboardAppearance: .light
+		diffCompareAccent: WKColor.orange600
 	)
     
     public static let sepia = WKTheme(
         name: "Sepia",
+		userInterfaceStyle: .light,
+		keyboardAppearance: .light,
         text: WKColor.gray700,
         secondaryText: WKColor.taupe600,
-        link: .blue600,
-        destructive: .red700,
-        border: .taupe200,
+        link: WKColor.blue600,
+        destructive: WKColor.red700,
+        border: WKColor.taupe200,
         paperBackground: WKColor.beige100,
         accessoryBackground: WKColor.beige300,
         inputAccessoryButtonTint: WKColor.gray600,
         inputAccessoryButtonSelectedTint: WKColor.gray700,
         inputAccessoryButtonSelectedBackgroundColor: WKColor.beige400,
         keyboardBarSearchFieldBackground: WKColor.gray200,
-        keyboardAppearance: .light
+		diffCompareAccent: WKColor.orange600
     )
 
 	public static let dark = WKTheme(
 		name: "Dark",
+		userInterfaceStyle: .dark,
+		keyboardAppearance: .dark,
         text: WKColor.gray100,
         secondaryText: WKColor.gray300,
-        link: .blue300,
-        destructive: .red600,
-        border: .gray650,
+        link: WKColor.blue300,
+        destructive: WKColor.red600,
+        border: WKColor.gray650,
         paperBackground: WKColor.gray675,
         accessoryBackground: WKColor.gray700,
         inputAccessoryButtonTint: WKColor.gray100,
         inputAccessoryButtonSelectedTint: WKColor.gray100,
         inputAccessoryButtonSelectedBackgroundColor: WKColor.gray800,
         keyboardBarSearchFieldBackground: WKColor.gray650,
-        keyboardAppearance: .dark
+		diffCompareAccent: WKColor.orange600
 	)
 
 	public static let black = WKTheme(
 		name: "Black",
+		userInterfaceStyle: .dark,
+		keyboardAppearance: .dark,
         text: WKColor.gray100,
         secondaryText: WKColor.gray300,
-        link: .blue300,
-        destructive: .red600,
-        border: .gray675,
+        link: WKColor.blue300,
+        destructive: WKColor.red600,
+        border: WKColor.gray675,
         paperBackground: WKColor.black,
         accessoryBackground: WKColor.gray700,
         inputAccessoryButtonTint: WKColor.gray100,
         inputAccessoryButtonSelectedTint: WKColor.gray100,
         inputAccessoryButtonSelectedBackgroundColor: WKColor.gray800,
         keyboardBarSearchFieldBackground: WKColor.gray650,
-        keyboardAppearance: .dark
+		diffCompareAccent: WKColor.orange600
 	)
 
 }


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T335579 (partially)

### Notes
This PR adds `WKMenuButton`, a button that presents a `UIMenu` as its primary action. This component was created to be used both in the updated diff view and the new watchlist home view. See [Figma](https://www.figma.com/file/YFtut34Eaq3vwS0lJQPbbE/iOS-Watchlist?type=design&node-id=234-7759&t=ugRH4B4hpREG4at7-0) for original design.

### Test Steps
`MenuButtonViewController` in the Demo app presents two example buttons.

