### PR TITLE
Remove undo and rollback examples

### DIFF
--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wikimedia/wikipedia-ios-data.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "9d2595265f6d726c1d29df73449225b0a36ea23a"
+        "branch" : "diff-undo-rollback-tweaks",
+        "revision" : "ceb49b6f320b8e95e829fca416ca48dc324208bd"
       }
     }
   ],

--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wikimedia/wikipedia-ios-data.git",
       "state" : {
-        "branch" : "diff-undo-rollback-tweaks",
-        "revision" : "ceb49b6f320b8e95e829fca416ca48dc324208bd"
+        "branch" : "main",
+        "revision" : "a208d5dc1e5b68dd2fa11227fa485a54ed1893af"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wikimedia/wikipedia-ios-data.git",
       "state" : {
-        "branch" : "watchlist-api-1",
-        "revision" : "d3feae0f5365d048b7c433f2be84a7e93e8ec106"
+        "branch" : "main",
+        "revision" : "9d2595265f6d726c1d29df73449225b0a36ea23a"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["Components"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/wikimedia/wikipedia-ios-data.git", branch: "diff-undo-rollback-tweaks")
+        .package(url: "https://github.com/wikimedia/wikipedia-ios-data.git", branch: "main")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["Components"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/wikimedia/wikipedia-ios-data.git", branch: "main")
+        .package(url: "https://github.com/wikimedia/wikipedia-ios-data.git", branch: "diff-undo-rollback-tweaks")
     ],
     targets: [
         .target(

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
@@ -155,16 +155,6 @@ public final class WKWatchlistViewController: WKCanvasViewController {
                 self.updateItemExpiryToSixMonths(item)
             }))
             
-            alert.addAction(UIAlertAction(title: "Undo", style: .default, handler:{ (UIAlertAction)in
-                self.undoRevision(item)
-            }))
-            
-            if hasRollbackRights {
-                alert.addAction(UIAlertAction(title: "Rollback", style: .default, handler:{ (UIAlertAction)in
-                    self.rollback(item)
-                }))
-            }
-            
         } else {
             alert.addAction(UIAlertAction(title: "Watch", style: .default , handler:{ (UIAlertAction)in
                 self.watchItem(item)
@@ -204,30 +194,5 @@ public final class WKWatchlistViewController: WKCanvasViewController {
     
     private func updateItemExpiryToSixMonths(_ item: WKWatchlistViewModel.ItemViewModel) {
         viewModel.watchItem(item, expiry: .sixMonths)
-    }
-    
-    private func undoRevision(_ item: WKWatchlistViewModel.ItemViewModel) {
-        
-        let alertController = UIAlertController(title: "Undo edits", message: "This will undo the changes made by the revision of the article shown here. To continue, please provide a reason for undoing this edit.", preferredStyle: .alert)
-        alertController.addTextField()
-
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-        let undoAction = UIAlertAction(title: "Undo", style: .default) { [weak alertController, weak self] _ in
-            guard let summary = alertController?.textFields?[0].text else {
-                return
-            }
-            
-            self?.viewModel.undoRevision(item, summary: summary)
-        }
-        
-        alertController.addAction(cancelAction)
-        alertController.addAction(undoAction)
-
-
-        present(alertController, animated: true)
-    }
-    
-    private func rollback(_ item: WKWatchlistViewModel.ItemViewModel) {
-        viewModel.rollback(item)
     }
 }

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
@@ -74,28 +74,4 @@ public class WKWatchlistViewModel {
             }
         }
     }
-    
-    func undoRevision(_ item: ItemViewModel, summary: String) {
-        service.undo(title: item.title, revisionID: item.revisionID, summary: summary, username: item.username, project: item.project) { result in
-            switch result {
-            case .success(()):
-                print("success!")
-            case .failure(let error):
-                print(error)
-            }
-        }
-    }
-    
-    func rollback(_ item: ItemViewModel) {
-        service.rollback(title: item.title, project: item.project, username: item.username) { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(()):
-                    print("success!")
-                case .failure(let error):
-                    print(error)
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T335579


### Notes
I had to change the contract for the undo / rollback API calls (see https://github.com/wikimedia/wikipedia-ios-data/pull/3, which this depends on).

Instead of updating the calls, I decided to remove them from the watchlist components, since we will not be actually making the calls from here, and are instead making them from the client diff screen.

Note: once https://github.com/wikimedia/wikipedia-ios-data/pull/3 is merged, please point the data dependency branch back to `main` before merging this PR.

**Test Steps**
Run demo app, confirm Undo and Rollback options are no longer presented in the Watchlist actions.
