### PR TITLE
Point data dependency to particular revision

### DIFF
--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wikimedia/wikipedia-ios-data.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "a208d5dc1e5b68dd2fa11227fa485a54ed1893af"
+        "revision" : "a3e08df3650ee4942210daf579e59f6de3625202"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["Components"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/wikimedia/wikipedia-ios-data.git", branch: "main")
+        .package(url: "https://github.com/wikimedia/wikipedia-ios-data.git", revision: "a3e08df3650ee4942210daf579e59f6de3625202")
     ],
     targets: [
         .target(


### PR DESCRIPTION
**Phabricator:** 
N/A

### Notes
Use the last approved revision in the data dependency instead of the `main` branch, to avoid breaking changes.

