### PR TITLE
Allow Watchlist to show / hide navigation bar upon appearance / disappearance

### DIFF
--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wikimedia/wikipedia-ios-data.git",
       "state" : {
-        "revision" : "a3e08df3650ee4942210daf579e59f6de3625202"
+        "revision" : "cb1ba717aa7ecc9475d28e2ea1a89c642caa1d09"
       }
     }
   ],

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -110,7 +110,7 @@ class ViewController: WKCanvasViewController {
             WKLanguage(languageCode: "es", languageVariantCode: nil)
         ])
 
-        let viewModel = WKWatchlistViewModel(localizedStrings: WKWatchlistViewModel.LocalizedStrings(title: "Watchlist", filter: "Filter"), configuration: WKWatchlistViewModel.Configuration())
+        let viewModel = WKWatchlistViewModel(localizedStrings: WKWatchlistViewModel.LocalizedStrings(title: "Watchlist", filter: "Filter"), presentationConfiguration: WKWatchlistViewModel.PresentationConfiguration())
 		let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, delegate: nil)
 		navigationController?.pushViewController(watchlistViewController, animated: true)
     }

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -110,7 +110,7 @@ class ViewController: WKCanvasViewController {
             WKLanguage(languageCode: "es", languageVariantCode: nil)
         ])
 
-		let viewModel = WKWatchlistViewModel(localizedStrings: WKWatchlistViewModel.LocalizedStrings(title: "Watchlist", filter: "Filter"))
+        let viewModel = WKWatchlistViewModel(localizedStrings: WKWatchlistViewModel.LocalizedStrings(title: "Watchlist", filter: "Filter"), configuration: WKWatchlistViewModel.Configuration())
 		let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, delegate: nil)
 		navigationController?.pushViewController(watchlistViewController, animated: true)
     }

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["Components"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/wikimedia/wikipedia-ios-data.git", revision: "a3e08df3650ee4942210daf579e59f6de3625202")
+        .package(url: "https://github.com/wikimedia/wikipedia-ios-data.git", revision: "cb1ba717aa7ecc9475d28e2ea1a89c642caa1d09")
     ],
     targets: [
         .target(

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
@@ -35,12 +35,26 @@ public final class WKWatchlistViewController: WKCanvasViewController {
 	public override func viewDidLoad() {
 		super.viewDidLoad()
 		addComponent(hostingViewController, pinToEdges: true)
-
 		self.title = viewModel.localizedStrings.title
-		self.navigationController?.setNavigationBarHidden(false, animated: true)
 		navigationItem.rightBarButtonItem = filterBarButton
 	}
 
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        if viewModel.configuration.showNavBarUponAppearance {
+            navigationController?.setNavigationBarHidden(false, animated: false)
+        }
+        
+    }
+    
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        if viewModel.configuration.hideNavBarUponDisappearance {
+            self.navigationController?.setNavigationBarHidden(true, animated: false)
+        }
+    }
 }
 
 fileprivate final class WKWatchlistHostingViewController: WKComponentHostingController<WKWatchlistView> {

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
@@ -42,7 +42,7 @@ public final class WKWatchlistViewController: WKCanvasViewController {
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if viewModel.configuration.showNavBarUponAppearance {
+        if viewModel.presentationConfiguration.showNavBarUponAppearance {
             navigationController?.setNavigationBarHidden(false, animated: false)
         }
         
@@ -51,7 +51,7 @@ public final class WKWatchlistViewController: WKCanvasViewController {
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
-        if viewModel.configuration.hideNavBarUponDisappearance {
+        if viewModel.presentationConfiguration.hideNavBarUponDisappearance {
             self.navigationController?.setNavigationBarHidden(true, animated: false)
         }
     }

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
@@ -14,7 +14,7 @@ public final class WKWatchlistViewModel {
 		}
 	}
     
-    public struct Configuration {
+    public struct PresentationConfiguration {
         let showNavBarUponAppearance: Bool
         let hideNavBarUponDisappearance: Bool
         
@@ -27,13 +27,13 @@ public final class WKWatchlistViewModel {
 	// MARK: - Properties
 
 	var localizedStrings: LocalizedStrings
-    let configuration: Configuration
+    let presentationConfiguration: PresentationConfiguration
 
 	// MARK: - Lifecycle
 
-    public init(localizedStrings: LocalizedStrings, configuration: Configuration) {
+    public init(localizedStrings: LocalizedStrings, presentationConfiguration: PresentationConfiguration) {
 		self.localizedStrings = localizedStrings
-        self.configuration = configuration
+        self.presentationConfiguration = presentationConfiguration
 	}
 	
 }

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
@@ -13,15 +13,27 @@ public final class WKWatchlistViewModel {
 			self.filter = filter
 		}
 	}
+    
+    public struct Configuration {
+        let showNavBarUponAppearance: Bool
+        let hideNavBarUponDisappearance: Bool
+        
+        public init(showNavBarUponAppearance: Bool = false, hideNavBarUponDisappearance: Bool = false) {
+            self.showNavBarUponAppearance = showNavBarUponAppearance
+            self.hideNavBarUponDisappearance = hideNavBarUponDisappearance
+        }
+    }
 
 	// MARK: - Properties
 
 	var localizedStrings: LocalizedStrings
+    let configuration: Configuration
 
 	// MARK: - Lifecycle
 
-	public init(localizedStrings: LocalizedStrings) {
+    public init(localizedStrings: LocalizedStrings, configuration: Configuration) {
 		self.localizedStrings = localizedStrings
+        self.configuration = configuration
 	}
 	
 }


### PR DESCRIPTION
**Phabricator:** 
https://phabricator.wikimedia.org/T335816

### Notes
When working on pushing the watchlist view from the new watchlist entry point in https://phabricator.wikimedia.org/T335816, I found that I needed this logic for it to play nicely with our surrounding view controllers in the stack that have a custom navigation bar.

I did try alternative approaches, like explicitly telling `ArticleViewController` to hide its navigation bar again on appearance, but that seemed to break the article's navigation bar. I suspect once we hook into pushing along to the diff view, it will also break there as well without this change.

Note: I also need a Data change for this task, so this is dependent on https://github.com/wikimedia/wikipedia-ios-data/pull/7.

