### PR TITLE
Add reachability toast handler and update delegate method

### DIFF
--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -147,7 +147,7 @@ class ViewController: WKCanvasViewController {
         
         let viewModel = WKWatchlistViewModel(localizedStrings: WKWatchlistViewModel.LocalizedStrings(title: "Watchlist", filter: "Filter", userButtonUserPage: "User page", userButtonTalkPage: "User talk page", userButtonContributions: "User contributions", userButtonThank: "Thank", byteChange: byteChange), presentationConfiguration: WKWatchlistViewModel.PresentationConfiguration())
         let filterViewModel = WKWatchlistFilterViewModel(localizedStrings: .demoStrings)
-		let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: filterViewModel, delegate: self, menuButtonDelegate: self)
+		let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: filterViewModel, delegate: self, menuButtonDelegate: self, reachabilityHandler: nil)
 		navigationController?.pushViewController(watchlistViewController, animated: true)
     }
 
@@ -249,10 +249,9 @@ extension ViewController: WKWatchlistDelegate {
 	func watchlistUserDidTapUser(username: String, action: Components.WKWatchlistUserButtonAction) {
 		print("Watchlist: user did tap \(username) → \(action)")
 	}
-	
 
-	func watchlistUserDidTapDiff(revisionID: UInt, oldRevisionID: UInt) {
-		print("Watchlist: user did tap diff \(revisionID) → \(oldRevisionID)")
+	func watchlistUserDidTapDiff(project: WKProject, articleTitle: String, revisionID: UInt, oldRevisionID: UInt) {
+		print("Watchlist: user did tap diff \(project) → \(articleTitle) → \(revisionID) → \(oldRevisionID)")
 	}
 
 }

--- a/Sources/Components/Components/Watchlist/WKWatchlistView.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistView.swift
@@ -5,7 +5,7 @@ struct WKWatchlistView: View {
 
 	@ObservedObject var appEnvironment = WKAppEnvironment.current
  	@ObservedObject var viewModel: WKWatchlistViewModel
-	
+
 	weak var delegate: WKWatchlistDelegate?
 	weak var menuButtonDelegate: WKMenuButtonDelegate?
 
@@ -15,7 +15,13 @@ struct WKWatchlistView: View {
 		ZStack {
 			Color(appEnvironment.theme.paperBackground)
 				.ignoresSafeArea()
-			WKWatchlistContentView(viewModel: viewModel, delegate: delegate, menuButtonDelegate: menuButtonDelegate)
+			if viewModel.hasPerformedInitialFetch {
+				WKWatchlistContentView(viewModel: viewModel, delegate: delegate, menuButtonDelegate: menuButtonDelegate)
+			} else {
+				ProgressView()
+			}
+		}.onAppear {
+			viewModel.fetchWatchlist()
 		}
 	}
 
@@ -45,7 +51,7 @@ private struct WKWatchlistContentView: View {
 							WKWatchlistViewCell(itemViewModel: item, localizedStrings: viewModel.localizedStrings, menuButtonDelegate: menuButtonDelegate)
 								.contentShape(Rectangle())
 								.onTapGesture {
-									delegate?.watchlistUserDidTapDiff(revisionID: item.revisionID, oldRevisionID: item.oldRevisionID)
+									delegate?.watchlistUserDidTapDiff(project: item.project, articleTitle: item.title, revisionID: item.revisionID, oldRevisionID: item.oldRevisionID)
 								}
 						}
 						.padding([.top, .bottom], 6)

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
@@ -107,13 +107,13 @@ public final class WKWatchlistViewModel: ObservableObject {
 
 	@Published var sections: [SectionViewModel] = []
     @Published var activeFilterCount: Int = 0
+	@Published var hasPerformedInitialFetch = false
 
 	// MARK: - Lifecycle
 
-    public init(localizedStrings: LocalizedStrings, presentationConfiguration: PresentationConfiguration) {
+	public init(localizedStrings: LocalizedStrings, presentationConfiguration: PresentationConfiguration) {
 		self.localizedStrings = localizedStrings
         self.presentationConfiguration = presentationConfiguration
-		fetchWatchlist()
 	}
 
 	public func fetchWatchlist() {
@@ -126,8 +126,9 @@ public final class WKWatchlistViewModel: ObservableObject {
 				}
 				self.sections = self.sortWatchlistItems()
                 self.activeFilterCount = watchlist.activeFilterCount
+				self.hasPerformedInitialFetch = true
 			case .failure(_):
-				break
+				self.hasPerformedInitialFetch = true
 			}
 		}
 	}


### PR DESCRIPTION
**Phabricator:** https://phabricator.wikimedia.org/T335606

### Notes
* Adds reachability handler to allow main client app to present internet connectivity toasts as needed
* Updates delegate method for diffs to also pass along `WKProject` and article title
* Adds a `ProgressView` loading spinner to the view until the watchlist until the first fetch action is completed 

I think the thank toast can actually be handled via the watchlist delegate method for user actions, but I can always create something similar to `ReachabilityHandler` if there are toast cases I'm not considering.

The client app PR that implements this is: https://github.com/wikimedia/wikipedia-ios/pull/4618

