### PR TITLE
Watchlist - Remove `menuButtonDelegate` from initializer

### DIFF
--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -179,7 +179,7 @@ class ViewController: WKCanvasViewController {
 
         let filterViewModel = WKWatchlistFilterViewModel(localizedStrings: .demoStrings)
 
-        let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: filterViewModel, emptyViewModel: emptyViewModel, delegate: self, menuButtonDelegate: self)
+        let watchlistViewController = WKWatchlistViewController(viewModel: viewModel, filterViewModel: filterViewModel, emptyViewModel: emptyViewModel, delegate: self)
 
 		navigationController?.pushViewController(watchlistViewController, animated: true)
     }

--- a/Sources/Components/Components/Watchlist/WKWatchlistView.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistView.swift
@@ -60,7 +60,7 @@ private struct WKWatchlistContentView: View {
 							.padding([.top, .bottom], 6)
 							.frame(maxWidth: .infinity, alignment: .leading)
 						ForEach(section.items) { item in
-							WKWatchlistViewCell(itemViewModel: item, localizedStrings: viewModel.localizedStrings, menuButtonDelegate: menuButtonDelegate)
+							WKWatchlistViewCell(itemViewModel: item, localizedStrings: viewModel.localizedStrings, menuButtonItems: viewModel.menuButtonItems, menuButtonDelegate: menuButtonDelegate)
 								.contentShape(Rectangle())
 								.onTapGesture {
 									delegate?.watchlistUserDidTapDiff(project: item.project, title: item.title, revisionID: item.revisionID, oldRevisionID: item.oldRevisionID)
@@ -86,6 +86,7 @@ private struct WKWatchlistViewCell: View {
 	@ObservedObject var appEnvironment = WKAppEnvironment.current
 	let itemViewModel: WKWatchlistViewModel.ItemViewModel
 	let localizedStrings: WKWatchlistViewModel.LocalizedStrings
+	let menuButtonItems: [WKMenuButton.MenuItem]
 
 	weak var menuButtonDelegate: WKMenuButtonDelegate?
 
@@ -136,12 +137,7 @@ private struct WKWatchlistViewCell: View {
 									title: itemViewModel.username,
 									image: WKSFSymbolIcon.for(symbol: .personFilled),
 									primaryColor: \.link,
-									menuItems: [
-										WKMenuButton.MenuItem(title: localizedStrings.userButtonUserPage, image: WKSFSymbolIcon.for(symbol: .person)),
-										WKMenuButton.MenuItem(title: localizedStrings.userButtonTalkPage, image: WKSFSymbolIcon.for(symbol: .conversation)),
-										WKMenuButton.MenuItem(title: localizedStrings.userButtonContributions, image: WKIcon.userContributions),
-										WKMenuButton.MenuItem(title: localizedStrings.userButtonThank, image: WKIcon.thank)
-									]
+									menuItems: menuButtonItems
 								), menuButtonDelegate: menuButtonDelegate)
 								Spacer()
 							}

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
@@ -109,11 +109,19 @@ public final class WKWatchlistViewModel: ObservableObject {
     @Published public var activeFilterCount: Int = 0
 	@Published var hasPerformedInitialFetch = false
 
+	let menuButtonItems: [WKMenuButton.MenuItem]
+
 	// MARK: - Lifecycle
 
     public init(localizedStrings: LocalizedStrings, presentationConfiguration: PresentationConfiguration) {
 		self.localizedStrings = localizedStrings
         self.presentationConfiguration = presentationConfiguration
+		self.menuButtonItems = [
+			WKMenuButton.MenuItem(title: localizedStrings.userButtonUserPage, image: WKSFSymbolIcon.for(symbol: .person)),
+			WKMenuButton.MenuItem(title: localizedStrings.userButtonTalkPage, image: WKSFSymbolIcon.for(symbol: .conversation)),
+			WKMenuButton.MenuItem(title: localizedStrings.userButtonContributions, image: WKIcon.userContributions),
+			WKMenuButton.MenuItem(title: localizedStrings.userButtonThank, image: WKIcon.thank)
+		]
 	}
 
 	public func fetchWatchlist() {


### PR DESCRIPTION
Moves the responsibility from the client to conform to and retain a `menuButtonDelegate` to just relying on the instantiated `WKWatchlistViewController` to do so. Using the `WKWatchlistDelegate` methods, it passes the button actions via `watchlistUserDidTapUser(username: String, action: WKWatchlistUserButtonAction)`. If needed for metrics purposes, we can adapt this to also pass the button tap action (without an associated menu item) through to the client via that delegate method.

- Also moves the menu button item construction out of the SwiftUI view into the view model

To test, confirm that when tapping Watchlist user menu button items that the action is still printed to the console.