### PR TITLE
Watchlist - Make `emptyViewDelegate` reference weak

### DIFF
--- a/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
@@ -114,7 +114,7 @@ fileprivate final class WKWatchlistHostingViewController: WKComponentHostingCont
 
 	let viewModel: WKWatchlistViewModel
     let emptyViewModel: WKEmptyViewModel
-    var emptyViewDelegate: WKEmptyViewDelegate? = nil {
+    weak var emptyViewDelegate: WKEmptyViewDelegate? = nil {
         didSet {
             rootView.emptyViewDelegate = emptyViewDelegate
         }


### PR DESCRIPTION
Makes `emptyViewDelegate` reference in `WKWatchlistHostingViewController` weak to avoid strong reference cycle.

### Test Steps
1. Confirm on `main` branch navigating to and away from the watchlist does not deinitialize `WKWatchlistHostingViewController` and `WKWatchlistViewController`
2. On this branch, confirm that `WKWatchlistHostingViewController` and `WKWatchlistViewController` deinitialize when navigating away from watchlist