### PR TITLE
Watchlist - Pass `WKProject` through delegate method on user button tap

### DIFF
--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -332,8 +332,8 @@ extension ViewController: WKWatchlistDelegate {
         print("Empty view: did tap search")
     }
 
-    func watchlistUserDidTapUser(username: String, action: Components.WKWatchlistUserButtonAction) {
-        print("Watchlist: user did tap \(username) → \(action)")
+	func watchlistUserDidTapUser (project: WKProject, username: String, action: Components.WKWatchlistUserButtonAction) {
+        print("Watchlist: user did tap \(project) → \(username) → \(action)")
     }
 
 	func watchlistUserDidTapDiff(project: WKProject, title: String, revisionID: UInt, oldRevisionID: UInt) {

--- a/Sources/Components/Components/Shared/Buttons/WKMenuButton.swift
+++ b/Sources/Components/Components/Shared/Buttons/WKMenuButton.swift
@@ -31,14 +31,16 @@ public class WKMenuButton: WKComponentView {
         let image: UIImage?
         let primaryColor: KeyPath<WKTheme, UIColor>
         public let menuItems: [MenuItem]
+		public var metadata: [String: Any] = [:]
 
 		// MARK: - Public
 
-        public init(title: String? = nil, image: UIImage? = nil, primaryColor: KeyPath<WKTheme, UIColor>,  menuItems: [MenuItem]) {
+		public init(title: String? = nil, image: UIImage? = nil, primaryColor: KeyPath<WKTheme, UIColor>,  menuItems: [MenuItem], metadata: [String: Any] = [:]) {
             self.title = title
             self.image = image
             self.primaryColor = primaryColor
             self.menuItems = menuItems
+			self.metadata = metadata
         }
 		
 	}

--- a/Sources/Components/Components/Watchlist/WKWatchlistView.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WKData
 
 // MARK: - WKWatchlistView
 struct WKWatchlistView: View {
@@ -137,7 +138,8 @@ private struct WKWatchlistViewCell: View {
 									title: itemViewModel.username,
 									image: WKSFSymbolIcon.for(symbol: .personFilled),
 									primaryColor: \.link,
-									menuItems: menuButtonItems
+									menuItems: menuButtonItems,
+									metadata: [WKWatchlistViewModel.ItemViewModel.wkProjectMetadataKey: itemViewModel.project]
 								), menuButtonDelegate: menuButtonDelegate)
 								Spacer()
 							}

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewController.swift
@@ -7,7 +7,7 @@ public protocol WKWatchlistDelegate: AnyObject {
 	func watchlistDidDismiss()
     func emptyViewDidTapSearch()
 	func watchlistUserDidTapDiff(project: WKProject, title: String, revisionID: UInt, oldRevisionID: UInt)
-	func watchlistUserDidTapUser(username: String, action: WKWatchlistUserButtonAction)
+	func watchlistUserDidTapUser(project: WKProject, username: String, action: WKWatchlistUserButtonAction)
 
 }
 
@@ -25,14 +25,16 @@ public final class WKWatchlistViewController: WKCanvasViewController {
 	class MenuButtonHandler: WKMenuButtonDelegate {
 		weak var watchlistDelegate: WKWatchlistDelegate?
 		let menuButtonItems: [WKMenuButton.MenuItem]
+		let wkProjectMetadataKey: String
 
-		init(watchlistDelegate: WKWatchlistDelegate? = nil, menuButtonItems: [WKMenuButton.MenuItem]) {
+		init(watchlistDelegate: WKWatchlistDelegate? = nil, menuButtonItems: [WKMenuButton.MenuItem], wkProjectMetadataKey: String) {
 			self.watchlistDelegate = watchlistDelegate
 			self.menuButtonItems = menuButtonItems
+			self.wkProjectMetadataKey = wkProjectMetadataKey
 		}
 
 		func wkSwiftUIMenuButtonUserDidTap(configuration: WKMenuButton.Configuration, item: WKMenuButton.MenuItem?) {
-			guard let username = configuration.title, let tappedTitle = item?.title else {
+			guard let username = configuration.title, let tappedTitle = item?.title, let wkProject = configuration.metadata[wkProjectMetadataKey] as? WKProject else {
 				return
 			}
 
@@ -41,13 +43,13 @@ public final class WKWatchlistViewController: WKCanvasViewController {
 			}
 
 			if tappedTitle == menuButtonItems[0].title {
-				watchlistDelegate?.watchlistUserDidTapUser(username: username, action: .userPage)
+				watchlistDelegate?.watchlistUserDidTapUser(project: wkProject, username: username, action: .userPage)
 			} else if tappedTitle == menuButtonItems[1].title {
-				watchlistDelegate?.watchlistUserDidTapUser(username: username, action: .userTalkPage)
+				watchlistDelegate?.watchlistUserDidTapUser(project: wkProject, username: username, action: .userTalkPage)
 			} else if tappedTitle == menuButtonItems[2].title {
-				watchlistDelegate?.watchlistUserDidTapUser(username: username, action: .userContributions)
+				watchlistDelegate?.watchlistUserDidTapUser(project: wkProject, username: username, action: .userContributions)
 			} else if tappedTitle == menuButtonItems[3].title {
-				watchlistDelegate?.watchlistUserDidTapUser(username: username, action: .thank)
+				watchlistDelegate?.watchlistUserDidTapUser(project: wkProject, username: username, action: .thank)
 			}
 		}
 	}
@@ -85,7 +87,7 @@ public final class WKWatchlistViewController: WKCanvasViewController {
 		self.delegate = delegate
 		self.reachabilityHandler = reachabilityHandler
 
-		let buttonHandler = MenuButtonHandler(watchlistDelegate: delegate, menuButtonItems: viewModel.menuButtonItems)
+		let buttonHandler = MenuButtonHandler(watchlistDelegate: delegate, menuButtonItems: viewModel.menuButtonItems, wkProjectMetadataKey: WKWatchlistViewModel.ItemViewModel.wkProjectMetadataKey)
 		self.buttonHandler = buttonHandler
 
         self.hostingViewController = WKWatchlistHostingViewController(viewModel: viewModel, emptyViewModel: emptyViewModel, delegate: delegate, menuButtonDelegate: buttonHandler)

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
@@ -27,7 +27,9 @@ public final class WKWatchlistViewModel: ObservableObject {
 		}
 	}
 
-	struct ItemViewModel: Identifiable {
+	public struct ItemViewModel: Identifiable {
+		public static let wkProjectMetadataKey = String(describing: WKProject.self)
+
 		public let id = UUID()
 
 		let title: String


### PR DESCRIPTION
### Notes
This passes the `WKProject` for an item through the watchlist delegate method when a user taps a button menu item. This lets the client app construct an appropriate site URL to route the user to. Depends on https://github.com/wikimedia/wikipedia-ios-components/pull/30. 

- Adds a `metadata` dictionary to `WKMenuButton.Configuration` to support sending along arbitrary data
- Updates the watchlist delegate to support receiving a `WKProject` on tap

### Test Steps
1. Open watchlist in Demo app
2. Tap a user button menu item and confirm the `WKProject` is printed to the console
