### PR TITLE
Watchlist - Increase tap area of user menu button

### DIFF
--- a/Sources/Components/Components/Shared/Buttons/WKSwiftUIMenuButton.swift
+++ b/Sources/Components/Components/Shared/Buttons/WKSwiftUIMenuButton.swift
@@ -37,13 +37,13 @@ public struct WKSwiftUIMenuButton: View {
 						.foregroundColor(Color(appEnvironment.theme[keyPath: configuration.primaryColor]))
 						.font(Font(WKFont.for(.boldFootnote)))
 				}
+				.padding([.leading, .trailing], 8)
+				.padding([.top, .bottom], 8)
+				.background(Color(appEnvironment.theme[keyPath: configuration.primaryColor].withAlphaComponent(0.15)))
 			})
 			.highPriorityGesture(TapGesture().onEnded {
 				menuButtonDelegate?.wkSwiftUIMenuButtonUserDidTap(configuration: configuration, item: nil)
 			})
-			.padding([.leading, .trailing], 8)
-			.padding([.top, .bottom], 8)
-			.background(Color(appEnvironment.theme[keyPath: configuration.primaryColor].withAlphaComponent(0.15)))
 			.cornerRadius(8)
 	}
 	


### PR DESCRIPTION
### Notes
Increase the tappable area of the user menu button.

### Test Steps
1. Open Watchlist in Demo app
2. Confirm the tappable area has increased compared to `main`
3. Confirm no visual regression in the menu button between this branch and `main`

