### PR TITLE
Watchlist - Don't show thank button for bots/anonymous users

### DIFF
--- a/Sources/Components/Components/Watchlist/WKWatchlistView.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistView.swift
@@ -61,7 +61,7 @@ private struct WKWatchlistContentView: View {
 							.padding([.top, .bottom], 6)
 							.frame(maxWidth: .infinity, alignment: .leading)
 						ForEach(section.items) { item in
-							WKWatchlistViewCell(itemViewModel: item, localizedStrings: viewModel.localizedStrings, menuButtonItems: viewModel.menuButtonItems, menuButtonDelegate: menuButtonDelegate)
+							WKWatchlistViewCell(itemViewModel: item, localizedStrings: viewModel.localizedStrings, menuItemConfiguration: WKWatchlistViewCell.MenuItemConfiguration(userMenuItems: viewModel.menuButtonItems, anonOrBotMenuItems: viewModel.menuButtonItemsWithoutThank), menuButtonDelegate: menuButtonDelegate)
 								.contentShape(Rectangle())
 								.onTapGesture {
 									delegate?.watchlistUserDidTapDiff(project: item.project, title: item.title, revisionID: item.revisionID, oldRevisionID: item.oldRevisionID)
@@ -82,12 +82,25 @@ private struct WKWatchlistContentView: View {
 
 // MARK: - Private: WKWatchlistViewCell
 
-private struct WKWatchlistViewCell: View {
+fileprivate struct WKWatchlistViewCell: View {
+
+	struct MenuItemConfiguration {
+		let userMenuItems: [WKMenuButton.MenuItem]
+		let anonOrBotMenuItems: [WKMenuButton.MenuItem]
+	}
 
 	@ObservedObject var appEnvironment = WKAppEnvironment.current
 	let itemViewModel: WKWatchlistViewModel.ItemViewModel
 	let localizedStrings: WKWatchlistViewModel.LocalizedStrings
-	let menuButtonItems: [WKMenuButton.MenuItem]
+	let menuItemConfiguration: MenuItemConfiguration
+
+	var menuItemsForRevisionAuthor: [WKMenuButton.MenuItem] {
+		if itemViewModel.isBot || itemViewModel.isAnonymous {
+			return menuItemConfiguration.anonOrBotMenuItems
+		} else {
+			return menuItemConfiguration.userMenuItems
+		}
+	}
 
 	weak var menuButtonDelegate: WKMenuButtonDelegate?
 
@@ -138,7 +151,7 @@ private struct WKWatchlistViewCell: View {
 									title: itemViewModel.username,
 									image: WKSFSymbolIcon.for(symbol: .personFilled),
 									primaryColor: \.link,
-									menuItems: menuButtonItems,
+									menuItems: menuItemsForRevisionAuthor,
 									metadata: [
 										WKWatchlistViewModel.ItemViewModel.wkProjectMetadataKey: itemViewModel.project,
 										WKWatchlistViewModel.ItemViewModel.revisionIDMetadataKey: itemViewModel.revisionID

--- a/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
+++ b/Sources/Components/Components/Watchlist/WKWatchlistViewModel.swift
@@ -38,17 +38,21 @@ public final class WKWatchlistViewModel: ObservableObject {
 		let commentWikitext: String
 		let timestamp: Date
 		let username: String
+		let isAnonymous: Bool
+		let isBot: Bool
 		let revisionID: UInt
 		let oldRevisionID: UInt
 		let byteChange: Int
 		let project: WKProject
 
-		public init(title: String, commentHTML: String, commentWikitext: String, timestamp: Date, username: String, revisionID: UInt, oldRevisionID: UInt, byteChange: Int, project: WKProject) {
+		public init(title: String, commentHTML: String, commentWikitext: String, timestamp: Date, username: String, isAnonymous: Bool, isBot: Bool, revisionID: UInt, oldRevisionID: UInt, byteChange: Int, project: WKProject) {
 			self.title = title
 			self.commentHTML = commentHTML
 			self.commentWikitext = commentWikitext
 			self.timestamp = timestamp
 			self.username = username
+			self.isAnonymous = isAnonymous
+			self.isBot = isBot
 			self.revisionID = revisionID
 			self.oldRevisionID = oldRevisionID
 			self.byteChange = byteChange
@@ -113,6 +117,7 @@ public final class WKWatchlistViewModel: ObservableObject {
 	@Published var hasPerformedInitialFetch = false
 
 	let menuButtonItems: [WKMenuButton.MenuItem]
+	var menuButtonItemsWithoutThank: [WKMenuButton.MenuItem]
 
 	// MARK: - Lifecycle
 
@@ -125,6 +130,7 @@ public final class WKWatchlistViewModel: ObservableObject {
 			WKMenuButton.MenuItem(title: localizedStrings.userButtonContributions, image: WKIcon.userContributions),
 			WKMenuButton.MenuItem(title: localizedStrings.userButtonThank, image: WKIcon.thank)
 		]
+		self.menuButtonItemsWithoutThank = self.menuButtonItems.dropLast()
 	}
 
 	public func fetchWatchlist() {
@@ -132,7 +138,7 @@ public final class WKWatchlistViewModel: ObservableObject {
 			switch result {
 			case .success(let watchlist):
 				self.items = watchlist.items.map { item in
-					let viewModel = ItemViewModel(title: item.title, commentHTML: item.commentHtml, commentWikitext: item.commentWikitext, timestamp: item.timestamp, username: item.username, revisionID: item.revisionID, oldRevisionID: item.oldRevisionID, byteChange: Int(item.byteLength) - Int(item.oldByteLength), project: item.project)
+					let viewModel = ItemViewModel(title: item.title, commentHTML: item.commentHtml, commentWikitext: item.commentWikitext, timestamp: item.timestamp, username: item.username, isAnonymous: item.isAnon, isBot: item.isBot, revisionID: item.revisionID, oldRevisionID: item.oldRevisionID, byteChange: Int(item.byteLength) - Int(item.oldByteLength), project: item.project)
 					return viewModel
 				}
 				self.sections = self.sortWatchlistItems()


### PR DESCRIPTION
### Notes
Removes the option to thank bots/anonymous users.

### Test Steps
1. Load Watchlist in Demo app
2. Find a cell with a revision change by an anonymous user (IP) and another by a bot – both examples available in first page or so of test data
3. Confirm neither show "Thank" in the user menu button
4. Confirm other user cells see the "Thank" button